### PR TITLE
Ensure tools output under central directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-
+Scan outputs are saved under the `outputs` directory at the project root. Every script will create its XML or text results inside this folder.

--- a/app/scripts/dirb_scan.py
+++ b/app/scripts/dirb_scan.py
@@ -1,7 +1,11 @@
+import os
 import subprocess
 import sys
 import validators
 from datetime import datetime
+
+OUTPUT_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'outputs')
+os.makedirs(OUTPUT_DIR, exist_ok=True)
 
 
 def validate_url(url):
@@ -16,7 +20,7 @@ def run_dirb(url):
         wordlist = "/usr/share/wordlists/dirb/common.txt"
         # Zaman damgası ile benzersiz bir çıktı dosyası adı oluşturulur
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        output_file = f"dirb_output_{timestamp}.xml"  # Yeni bir çıktı dosyası adı oluşturulur
+        output_file = os.path.join(OUTPUT_DIR, f"dirb_output_{timestamp}.xml")  # Yeni bir çıktı dosyası adı oluşturulur
         command = ["dirb", url, wordlist, "-o", output_file]  # Çıktıyı XML formatında kaydetmek için '-o' kullanılır
         print("\nGizli dizin taraması başlatıldı...\n")
 

--- a/app/scripts/dorkIntellegenceName.py
+++ b/app/scripts/dorkIntellegenceName.py
@@ -7,6 +7,9 @@ import xml.etree.ElementTree as ET
 import urllib.parse
 import time
 
+OUTPUT_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'outputs')
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
 def print_help():
     print("\nKullanım: python3 googledork.py <isim>\n")
 
@@ -76,7 +79,7 @@ def output_to_xml(name, results):
     xml_string = ET.tostring(root, encoding="unicode")
 
     # XML dosyasını kaydet
-    filename = f"GoogleDorkResults_{name.replace(' ', '_')}.xml"
+    filename = os.path.join(OUTPUT_DIR, f"GoogleDorkResults_{name.replace(' ', '_')}.xml")
     with open(filename, 'w') as xml_file:
         xml_file.write(xml_string)
 

--- a/app/scripts/emailfinddomain.py
+++ b/app/scripts/emailfinddomain.py
@@ -7,6 +7,9 @@ import subprocess
 import xml.etree.ElementTree as ET
 from datetime import datetime
 
+OUTPUT_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'outputs')
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
 def print_help():
     print("\nKullanım: python3 emailfinddomain.py <domain>")
 
@@ -58,8 +61,8 @@ def output_to_xml(domain, email_data):
 def save_xml_to_file(xml_data):
     """XML verisini dosyaya kaydeder."""
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    filename = f"emailFindDomain_{timestamp}.xml"
-    
+    filename = os.path.join(OUTPUT_DIR, f"emailFindDomain_{timestamp}.xml")
+
     with open(filename, 'w') as xml_file:
         xml_file.write(xml_data)
     

--- a/app/scripts/emailfinder_script.py
+++ b/app/scripts/emailfinder_script.py
@@ -1,7 +1,10 @@
+import os
 import subprocess
 import sys
-import os
 import socket
+
+OUTPUT_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'outputs')
+os.makedirs(OUTPUT_DIR, exist_ok=True)
 
 def check_emailfinder_installed():
     """Emailfinder aracının yüklü olup olmadığını kontrol eder."""
@@ -25,7 +28,7 @@ def validate_domain(domain):
 def run_emailfinder(domain):
     """Emailfinder aracını belirtilen domain üzerinde çalıştırır."""
     try:
-        output_file = "emailfinder_out.txt"
+        output_file = os.path.join(OUTPUT_DIR, "emailfinder_out.txt")
         command = ["emailfinder", "-d", domain]
         print("\nTarama başlatıldı, email bilgileri tespit ediliyor...\n")
         result = subprocess.run(command, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/app/scripts/googleDork.py
+++ b/app/scripts/googleDork.py
@@ -1,8 +1,12 @@
+import os
 import requests
 import sys
 import xml.etree.ElementTree as ET
 from urllib.parse import quote
 import validators
+
+OUTPUT_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'outputs')
+os.makedirs(OUTPUT_DIR, exist_ok=True)
 
 def generate_dork_url(domain, dork):
     """Belirtilen domain ve dork için Google arama URL'sini oluşturur."""
@@ -35,8 +39,9 @@ def fetch_dork_results(domain, dorks):
             ET.SubElement(domain_element, "dork_result", type=dork).text = f"Unexpected error: {str(e)}"
 
     tree = ET.ElementTree(root)
-    tree.write(f"{domain}_dork_results.xml", encoding='utf-8', xml_declaration=True)
-    print(f"Veriler {domain}_dork_results.xml dosyasına kaydedildi.")
+    output_file = os.path.join(OUTPUT_DIR, f"{domain}_dork_results.xml")
+    tree.write(output_file, encoding='utf-8', xml_declaration=True)
+    print(f"Veriler {output_file} dosyasına kaydedildi.")
 
 def validate_domain(domain):
     """Domain'in geçerli olup olmadığını kontrol eder."""

--- a/app/scripts/localExploredevice.py
+++ b/app/scripts/localExploredevice.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python3
 
+import os
 import sys
 import subprocess
 import xml.etree.ElementTree as ET
+
+OUTPUT_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'outputs')
+os.makedirs(OUTPUT_DIR, exist_ok=True)
 
 def print_help():
     print("\nKullanım: python localExploredevice.py <interface> <ip_cidr_notation>\n")
@@ -46,7 +50,7 @@ def output_to_xml(data):
     xml_string = ET.tostring(root, encoding="unicode")
 
     # XML dosyasını kaydet
-    filename = "ArpScanResults.xml"
+    filename = os.path.join(OUTPUT_DIR, "ArpScanResults.xml")
     with open(filename, 'w') as xml_file:
         xml_file.write(xml_string)
 

--- a/app/scripts/metagoofil.py
+++ b/app/scripts/metagoofil.py
@@ -1,6 +1,9 @@
+import os
 import subprocess
 import sys
-import os
+
+OUTPUT_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'outputs')
+os.makedirs(OUTPUT_DIR, exist_ok=True)
 
 def check_metagoofil_installed():
     """Metagoofil aracının yüklü olup olmadığını kontrol eder."""
@@ -16,7 +19,10 @@ def check_metagoofil_installed():
 def run_metagoofil(domain):
     """Metagoofil aracını belirtilen domain üzerinde çalıştırır."""
     try:
-        command = ["metagoofil", "-d", domain, "-t", "pdf,doc,docx,xlsx","-o","metagoofil_result","-f","metagoofil.html","-e", "2"]
+        output_dir = os.path.join(OUTPUT_DIR, "metagoofil_result")
+        os.makedirs(output_dir, exist_ok=True)
+        output_html = os.path.join(output_dir, "metagoofil.html")
+        command = ["metagoofil", "-d", domain, "-t", "pdf,doc,docx,xlsx", "-o", output_dir, "-f", output_html, "-e", "2"]
         result = subprocess.run(command, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         print("Metagoofil çıktısı:\n", result.stdout.decode())
     except subprocess.CalledProcessError as e:

--- a/app/scripts/nikto_script.py
+++ b/app/scripts/nikto_script.py
@@ -1,6 +1,10 @@
 
+import os
 import subprocess
 import sys
+
+OUTPUT_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'outputs')
+os.makedirs(OUTPUT_DIR, exist_ok=True)
 
 def check_nikto_installed():
     try:
@@ -17,7 +21,7 @@ def check_nikto_installed():
         sys.exit(1)
 
 def perform_scan(domain, port, ssl_option):
-    output_file = f"{domain}_nikto_scan.xml"
+    output_file = os.path.join(OUTPUT_DIR, f"{domain}_nikto_scan.xml")
     ssl_flag = '-ssl' if ssl_option == 'ssl' else '-nossl'
     
     try:

--- a/app/scripts/nmap_script.py
+++ b/app/scripts/nmap_script.py
@@ -1,10 +1,14 @@
+import os
 import nmap
 import sys
 import time
 
+OUTPUT_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'outputs')
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
 def perform_scan(domain, scan_type):
     nm = nmap.PortScanner()
-    output_file = f"{domain}_nmap_scan.xml"
+    output_file = os.path.join(OUTPUT_DIR, f"{domain}_nmap_scan.xml")
     
     try:
         if scan_type == '1':

--- a/app/scripts/owaspZap_script.py
+++ b/app/scripts/owaspZap_script.py
@@ -4,6 +4,9 @@ import sys
 import re
 import time
 
+OUTPUT_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'outputs')
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
 def check_zap_installed():
     """ZAP aracının yüklü olup olmadığını kontrol eder."""
     try:
@@ -29,7 +32,7 @@ def run_zap(url):
     print("\nTarama Başlatılıyor...")
     time.sleep(2)
 
-    output_file = "owaspZap_scanResult.xml"
+    output_file = os.path.join(OUTPUT_DIR, "owaspZap_scanResult.xml")
 
     try:
         # ZAP'ı başlat ve taramayı gerçekleştir

--- a/app/scripts/raccoon_script.py
+++ b/app/scripts/raccoon_script.py
@@ -1,6 +1,10 @@
+import os
 import subprocess
 import sys
 import time
+
+OUTPUT_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'outputs')
+os.makedirs(OUTPUT_DIR, exist_ok=True)
 
 def check_raccoon_installed():
     try:
@@ -17,13 +21,13 @@ def check_raccoon_installed():
         sys.exit(1)
 
 def perform_scan(domain):
-    output_file = f"{domain}_scan.xml"
+    output_file = os.path.join(OUTPUT_DIR, f"{domain}_scan.xml")
     
     try:
         # Raccoon ile tarama yap ve sonuçları XML dosyasına kaydet
         print(f"{domain} için tarama başlatılıyor...\n")
         time.sleep(1)
-        subprocess.run(['raccoon','-f', domain, '-o', output_file], check=True)   # -f --> full scan: -sV and -sC, scan version and Script(for exploit)
+        subprocess.run(['raccoon', '-f', domain, '-o', output_file], check=True)   # -f --> full scan
         print(f"Tarama tamamlandı. Sonuçlar {output_file} dosyasına kaydedildi.")
     except KeyboardInterrupt:
         print("Çıkış Yapıldı...")

--- a/app/scripts/skipfish_script.py
+++ b/app/scripts/skipfish_script.py
@@ -1,6 +1,10 @@
+import os
 import subprocess
 import sys
 import shutil
+
+OUTPUT_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'outputs')
+os.makedirs(OUTPUT_DIR, exist_ok=True)
 
 def check_skipfish_installed():
     skipfish_path = shutil.which('skipfish')
@@ -12,7 +16,7 @@ def check_skipfish_installed():
         sys.exit(1)
 
 def perform_scan(url):
-    output_file = "/home/kali/Documents/BilfenProject/skipfish"
+    output_file = os.path.join(OUTPUT_DIR, "skipfish")
     
     try:
         # Skipfish ile tarama yap ve sonuçları XML dosyasına kaydet

--- a/app/scripts/slowlorisDDOS.py
+++ b/app/scripts/slowlorisDDOS.py
@@ -1,7 +1,11 @@
+import os
 import subprocess
 import sys
 import validators
 import time
+
+OUTPUT_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'outputs')
+os.makedirs(OUTPUT_DIR, exist_ok=True)
 
 def check_slowhttptest_installed():
     """slowhttptest aracının yüklü olup olmadığını kontrol eder."""
@@ -23,9 +27,10 @@ def validate_url(url):
 def run_slowhttptest(url):
     """slowhttptest aracını belirtilen URL üzerinde çalıştırır ve terminale canlı çıktı verir."""
     try:
+        output_dir = os.path.join(OUTPUT_DIR, "slow-test")
         command = [
             "slowhttptest", "-c", "1000", "-H", "-r", "200", "-c", "400", "-i", "10",
-            "-t", "POST", "-l", "3600", "-o", "/home/kali/Documents/BilfenProject/slow-test",
+            "-t", "POST", "-l", "3600", "-o", output_dir,
             "-g", "-u", url
         ]
         print("\nSlowloriss Saldırısı başlatılıyor...\n")

--- a/app/scripts/socialAnalyzerName.py
+++ b/app/scripts/socialAnalyzerName.py
@@ -6,6 +6,9 @@ import subprocess
 import xml.etree.ElementTree as ET
 import time
 
+OUTPUT_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'outputs')
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
 def print_help():
     print("\nKullanım: python3 socialAnalyzerName.py <target_name>\n")
 
@@ -42,7 +45,7 @@ def output_to_xml(target_name, data):
     xml_string = ET.tostring(root, encoding="unicode")
 
     # XML dosyasını kaydet
-    filename = f"SocialAnalyzerResults_{target_name.replace(' ', '_')}.xml"
+    filename = os.path.join(OUTPUT_DIR, f"SocialAnalyzerResults_{target_name.replace(' ', '_')}.xml")
     with open(filename, 'w') as xml_file:
         xml_file.write(xml_string)
 

--- a/app/scripts/subdomain_detect.py
+++ b/app/scripts/subdomain_detect.py
@@ -1,5 +1,9 @@
+import os
 import subprocess
 import sys
+
+OUTPUT_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'outputs')
+os.makedirs(OUTPUT_DIR, exist_ok=True)
 
 def check_sublist3r_installed():
     """Sublist3r aracının yüklü olup olmadığını kontrol eder."""
@@ -15,7 +19,7 @@ def check_sublist3r_installed():
 def run_sublist3r(domain):
     """Sublist3r aracını belirtilen domain üzerinde çalıştırır ve sonuçları bir XML dosyasına kaydeder."""
     try:
-        output_file = "subdomain.xml"
+        output_file = os.path.join(OUTPUT_DIR, "subdomain.xml")
         command = ["sublist3r", "-v", "-d", domain, "-o", output_file]
         result = subprocess.run(command, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         print(f"Sublist3r çalışması tamamlandı. Çıktı dosyası: {output_file}")

--- a/app/scripts/uniscan_script.py
+++ b/app/scripts/uniscan_script.py
@@ -4,6 +4,9 @@ import sys
 import re
 import time
 
+OUTPUT_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'outputs')
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
 def check_uniscan_installed():
     """Uniscan aracının yüklü olup olmadığını kontrol eder."""
     try:
@@ -29,7 +32,7 @@ def run_uniscan(url):
     print("Tarama Başlatılıyor...")
     time.sleep(2)
 
-    output_file = "uniscan_output.xml"
+    output_file = os.path.join(OUTPUT_DIR, "uniscan_output.xml")
     
     try:
         # Uniscan komutunu çalıştır ve çıktıyı XML formatında kaydet

--- a/app/scripts/wapiti_script.py
+++ b/app/scripts/wapiti_script.py
@@ -1,6 +1,10 @@
+import os
 import subprocess
 import sys
 import shutil
+
+OUTPUT_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'outputs')
+os.makedirs(OUTPUT_DIR, exist_ok=True)
 
 def check_wapiti_installed():
     wapiti_path = shutil.which('wapiti')
@@ -12,8 +16,9 @@ def check_wapiti_installed():
         sys.exit(1)
 
 def perform_scan(url):
-    output_dir = '/home/kali/Documents/BilfenProject/wapitiScan'
-    output_file = f"{output_dir}/{url.split('//')[-1].replace('/', '_')}_wapiti.xml"
+    output_dir = os.path.join(OUTPUT_DIR, 'wapitiScan')
+    os.makedirs(output_dir, exist_ok=True)
+    output_file = os.path.join(output_dir, f"{url.split('//')[-1].replace('/', '_')}_wapiti.xml")
     
     try:
         # Wapiti ile tarama yap ve sonuçları XML dosyasına kaydet


### PR DESCRIPTION
## Summary
- define `OUTPUT_DIR` in all scanning scripts
- save results in the new directory using `os.path.join`
- mention new location for outputs in README

## Testing
- `python -m py_compile app/scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_683f8d45c9108333afb6953f69e3f65c